### PR TITLE
🐛 Fix promotion condition

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -21,15 +21,16 @@ steps:
         gcloud auth activate-service-account --key-file=gcloud-service-key.json
         gcloud config set project zen-formations
         gcloud config set app/use_appengine_api false
-  - unless:
-      condition:
-        matches:
-          pattern: ^(main|master)$
-          value: << parameters.version >>
-      steps:
-        - run:
-            name: Do not promote unless main branch
-            command: gcloud config set app/promote_by_default false
+  - run:
+      name: Promote only main branch
+      command: |
+        if [ "<< parameters.version >>" = 'main' -o "<< parameters.version >>" = 'master' ]; then
+          echo "Will promote"
+          gcloud config set app/promote_by_default true
+        else
+          echo "Will not promote"
+          gcloud config set app/promote_by_default false
+        fi
   - run:
       name: Generate AppEngine configuration
       command: |


### PR DESCRIPTION
With default value of 'parameters.version' at '', it was this literal (instead of value) that was use in the step condition

Example of fixed (with adapted condition for test branch): https://app.circleci.com/pipelines/github/Zenika-Training/training-template/234/workflows/33bf0756-2291-413e-8bd1-f31389c3d8c1/jobs/1004/parallel-runs/0/steps/0-104