### PR TITLE
Update python runtime for AppEngine

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
     default: $CIRCLE_BRANCH
 docker:
-  - image: google/cloud-sdk:334.0.0-alpine
+  - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:459.0.0-alpine
 resource_class: small
 steps:
   - checkout
@@ -21,7 +21,6 @@ steps:
         echo $GAE_KEY_FILE_CONTENT > gcloud-service-key.json
         gcloud auth activate-service-account --key-file=gcloud-service-key.json
         gcloud config set project zen-formations
-        gcloud config set app/use_appengine_api false
   - run:
       name: Promote only main branch
       command: |
@@ -37,9 +36,8 @@ steps:
       command: |
         cat \<<EOT > dist/app.yml
         service: << parameters.training-name >>
-        runtime: python27
-        api_version: 1
-        threadsafe: true
+        runtime: python312
+        app_engine_apis: false
         handlers:
         - url: /
           static_files: index.html


### PR DESCRIPTION
⚠️ Not tested at all! (don't really know how to check) ⚠️

Python 2.7 runtime will reach end of support on 2024-01-31 (https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#python), meaning that running ones will be ok but no more deployment possible (https://cloud.google.com/appengine/docs/standard/lifecycle/runtime-lifecycle#end_of_support)

Migration doc: https://cloud.google.com/appengine/migration-center/standard/migrate-to-second-gen/python-differences

https://cloud.google.com/appengine/docs/standard/python3/migrate-to-python3/config-files#updating_appyaml
> | handlers: login | Supported if app_engine_apis is true | If you are not using the legacy bundled services for Python 3, use Identity and Access Management (IAM) for user management. |

Meaning there may be something to do for "legacy bundled services for Python 3"

Project in GCP: https://console.cloud.google.com/appengine/services?serviceId=default&versionId=go-listing-3&project=zen-formations